### PR TITLE
Update version to SemVer format for compatibility with NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "WP-JS-Hooks",
   "props": "Carl Danley & 10up",
-  "version": "0.2",
+  "version": "0.2.0",
   "devDependencies": {
     "grunt": "~1.0.1",
     "grunt-contrib-jshint": "~1.1.0",


### PR DESCRIPTION
This is needed for NPM to be able to load the package directly from GitHub. Otherwise it throws a complaint: `npm ERR! Invalid version: "0.2"`. More info [here](http://stackoverflow.com/a/16888025/1320363).

Tested with: node 6.3.0, npm 4.0.3.